### PR TITLE
feat: redesign journal feed cards — Strava-inspired layout with scales, word count, photo

### DIFF
--- a/app/(main)/feed/page.tsx
+++ b/app/(main)/feed/page.tsx
@@ -13,7 +13,7 @@ import { auth } from '@/auth'
 import { redirect } from 'next/navigation'
 import Link from 'next/link'
 import { db } from '@/lib/db'
-import { posts, morningState, users } from '@/lib/db/schema'
+import { posts, morningState, users, wolfbotReviews } from '@/lib/db/schema'
 import { and, desc, eq, inArray } from 'drizzle-orm'
 import AnimatedRoutineIcons from '@/components/AnimatedRoutineIcons'
 import { deriveExcerpt } from '@/lib/posts'
@@ -24,7 +24,7 @@ function formatDate(iso: string) {
   return `${d.getDate()} ${months[d.getMonth()]} ${d.getFullYear()}`
 }
 
-function Avatar({ src, name, size = 28 }: { src: string | null; name: string; size?: number }) {
+function Avatar({ src, name, size = 40 }: { src: string | null; name: string; size?: number }) {
   const initials = name.split(' ').map(w => w[0]).join('').toUpperCase().slice(0, 2)
   if (src) {
     return (
@@ -50,12 +50,35 @@ function Avatar({ src, name, size = 28 }: { src: string | null; name: string; si
   )
 }
 
+// 1–8 → two-word band per scale type
+const SCALE_WORDS: Record<'happy' | 'body' | 'brain', string[]> = {
+  happy: ['Lost',    'Lost',    'Steady',  'Steady',  'Good',    'Good',    'Joyful',  'Joyful'],
+  body:  ['Drained', 'Drained', 'Moving',  'Moving',  'Charged', 'Charged', 'Buzzing', 'Buzzing'],
+  brain: ['Silent',  'Silent',  'Waking',  'Waking',  'Sharp',   'Sharp',   'Manic',   'Manic'],
+}
+
+function scaleWord(val: number | null, type: keyof typeof SCALE_WORDS): string | null {
+  if (!val || val < 1 || val > 8) return null
+  return SCALE_WORDS[type][val - 1]
+}
+
+function scaleColour(val: number | null): string {
+  if (!val) return '#909090'
+  if (val <= 2) return '#909090'
+  if (val <= 4) return '#4A7FA5'
+  if (val <= 6) return '#A0622A'
+  return '#3AB87A'
+}
+
 type FeedPost = {
   id: string
   slug: string
   title: string
   date: string
   excerpt: string | null
+  image: string | null
+  wordCountTotal: number | null
+  wolfbotReviewed: boolean
   status: string
   authorId: string | null
   authorUsername: string | null
@@ -64,6 +87,9 @@ type FeedPost = {
   authorAvatar: string | null
   authorImage: string | null
   checklist?: Record<string, boolean>
+  happyScale: number | null
+  bodyScale: number | null
+  brainScale: number | null
 }
 
 function FeedCard({ post, showAuthor }: { post: FeedPost; showAuthor: boolean }) {
@@ -71,28 +97,99 @@ function FeedCard({ post, showAuthor }: { post: FeedPost; showAuthor: boolean })
   const avatarSrc = post.authorAvatar ?? post.authorImage ?? null
   const url = post.authorUsername ? `/${post.authorUsername}/${post.slug}` : `/posts/${post.slug}`
   const isDraft = post.status === 'draft'
+  const cardUrl = isDraft ? `/edit/${post.id}` : url
+
+  const moodWord  = scaleWord(post.happyScale, 'happy')
+  const bodyWord  = scaleWord(post.bodyScale,  'body')
+  const brainWord = scaleWord(post.brainScale, 'brain')
+  const hasScales = !!(moodWord || bodyWord || brainWord)
+
+  const completedRituals = post.checklist
+    ? Object.values(post.checklist).filter(Boolean).length
+    : 0
+  const hasRituals = !!post.checklist && completedRituals > 0
 
   return (
     <article className="feed-card">
-      {showAuthor && post.authorUsername && (
-        <Link href={`/${post.authorUsername}`} className="feed-card-author">
-          <Avatar src={avatarSrc} name={authorName} size={24} />
-          <span className="feed-card-author-name">{authorName}</span>
+
+      {/* ── Header: avatar + name + date ── */}
+      {showAuthor && post.authorUsername ? (
+        <Link href={`/${post.authorUsername}`} className="feed-card-author-link">
+          <Avatar src={avatarSrc} name={authorName} size={40} />
+          <div className="feed-card-author-info">
+            <span className="feed-card-author-name">{authorName}</span>
+            <span className="feed-card-meta-date">
+              {formatDate(post.date)}
+              {isDraft && <span className="feed-card-draft-badge">draft</span>}
+            </span>
+          </div>
         </Link>
-      )}
-      <Link href={isDraft ? `/edit/${post.id}` : url} className="feed-card-link">
-        <span className="feed-card-date">
+      ) : (
+        <div className="feed-card-date-solo">
           {formatDate(post.date)}
           {isDraft && <span className="feed-card-draft-badge">draft</span>}
-        </span>
+        </div>
+      )}
+
+      {/* ── Title ── */}
+      <Link href={cardUrl} className="feed-card-title-link">
         <p className="feed-card-title">{post.title || 'Untitled'}</p>
-        {post.excerpt && (
-          <p className="feed-card-excerpt">{post.excerpt.slice(0, 160)}</p>
-        )}
       </Link>
-      {post.checklist && (
-        <div className="feed-card-rituals">
-          <AnimatedRoutineIcons checklist={post.checklist} size={16} />
+
+      {/* ── Scales strip ── */}
+      {hasScales && (
+        <div className="feed-card-scales">
+          {moodWord && (
+            <div className="feed-card-scale-pill">
+              <span className="feed-card-scale-label">MOOD</span>
+              <span className="feed-card-scale-word" style={{ color: scaleColour(post.happyScale) }}>{moodWord}</span>
+            </div>
+          )}
+          {bodyWord && (
+            <div className="feed-card-scale-pill">
+              <span className="feed-card-scale-label">BODY</span>
+              <span className="feed-card-scale-word" style={{ color: scaleColour(post.bodyScale) }}>{bodyWord}</span>
+            </div>
+          )}
+          {brainWord && (
+            <div className="feed-card-scale-pill">
+              <span className="feed-card-scale-label">BRAIN</span>
+              <span className="feed-card-scale-word" style={{ color: scaleColour(post.brainScale) }}>{brainWord}</span>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* ── Photo / fallback ── */}
+      <Link href={cardUrl} className="feed-card-media-link">
+        <div className="feed-card-media">
+          {post.image
+            ? <img src={post.image} alt={post.title} className="feed-card-photo" />
+            : <div className="feed-card-photo-fallback" />
+          }
+        </div>
+      </Link>
+
+      {/* ── Word count ── */}
+      {post.wordCountTotal ? (
+        <div className="feed-card-wordcount">
+          <span className="feed-card-wordcount-number">{post.wordCountTotal}</span>
+          <span className="feed-card-wordcount-label">words</span>
+        </div>
+      ) : null}
+
+      {/* ── Footer: rituals + WOLF|BOT badge ── */}
+      {(hasRituals || post.wolfbotReviewed) && (
+        <div className="feed-card-footer">
+          {hasRituals && (
+            <div className="feed-card-rituals">
+              <AnimatedRoutineIcons checklist={post.checklist!} size={14} />
+              <span className="feed-card-ritual-count">{completedRituals}/10</span>
+            </div>
+          )}
+          {post.wolfbotReviewed && (
+            <span className="feed-card-wolfbot-badge">WOLF|BOT ✓</span>
+          )}
         </div>
       )}
     </article>
@@ -121,6 +218,8 @@ export default async function FeedPage({
         date: posts.date,
         excerpt: posts.excerpt,
         content: posts.content,
+        image: posts.image,
+        wordCountTotal: posts.wordCountTotal,
         status: posts.status,
         authorId: posts.authorId,
         authorUsername: users.username,
@@ -135,15 +234,24 @@ export default async function FeedPage({
       .orderBy(desc(posts.date))
 
     const ids = rows.map(r => r.id)
-    const states = ids.length > 0
-      ? await db.select().from(morningState).where(inArray(morningState.postId, ids))
-      : []
-    const stateMap = new Map(states.map(s => [s.postId, s]))
+    const [states, reviews] = ids.length > 0
+      ? await Promise.all([
+          db.select().from(morningState).where(inArray(morningState.postId, ids)),
+          db.select({ postId: wolfbotReviews.postId }).from(wolfbotReviews).where(inArray(wolfbotReviews.postId, ids)),
+        ])
+      : [[], []]
+
+    const stateMap   = new Map(states.map(s => [s.postId, s]))
+    const reviewedIds = new Set(reviews.map(r => r.postId))
 
     feedPosts = rows.map(({ content, ...r }) => ({
       ...r,
       excerpt: r.excerpt || deriveExcerpt(content) || null,
       checklist: stateMap.get(r.id)?.routineChecklist as Record<string, boolean> | undefined,
+      happyScale: stateMap.get(r.id)?.happyScale ?? null,
+      bodyScale:  stateMap.get(r.id)?.bodyScale  ?? null,
+      brainScale: stateMap.get(r.id)?.brainScale ?? null,
+      wolfbotReviewed: reviewedIds.has(r.id),
     }))
   } else {
     const rows = await db
@@ -154,6 +262,8 @@ export default async function FeedPage({
         date: posts.date,
         excerpt: posts.excerpt,
         content: posts.content,
+        image: posts.image,
+        wordCountTotal: posts.wordCountTotal,
         status: posts.status,
         authorId: posts.authorId,
         authorUsername: users.username,
@@ -172,15 +282,24 @@ export default async function FeedPage({
       .orderBy(desc(posts.date))
 
     const ids = rows.map(r => r.id)
-    const states = ids.length > 0
-      ? await db.select().from(morningState).where(inArray(morningState.postId, ids))
-      : []
-    const stateMap = new Map(states.map(s => [s.postId, s]))
+    const [states, reviews] = ids.length > 0
+      ? await Promise.all([
+          db.select().from(morningState).where(inArray(morningState.postId, ids)),
+          db.select({ postId: wolfbotReviews.postId }).from(wolfbotReviews).where(inArray(wolfbotReviews.postId, ids)),
+        ])
+      : [[], []]
+
+    const stateMap    = new Map(states.map(s => [s.postId, s]))
+    const reviewedIds = new Set(reviews.map(r => r.postId))
 
     feedPosts = rows.map(({ content, ...r }) => ({
       ...r,
       excerpt: r.excerpt || deriveExcerpt(content) || null,
       checklist: stateMap.get(r.id)?.routineChecklist as Record<string, boolean> | undefined,
+      happyScale: stateMap.get(r.id)?.happyScale ?? null,
+      bodyScale:  stateMap.get(r.id)?.bodyScale  ?? null,
+      brainScale: stateMap.get(r.id)?.brainScale ?? null,
+      wolfbotReviewed: reviewedIds.has(r.id),
     }))
   }
 

--- a/app/(main)/feed/page.tsx
+++ b/app/(main)/feed/page.tsx
@@ -13,9 +13,10 @@ import { auth } from '@/auth'
 import { redirect } from 'next/navigation'
 import Link from 'next/link'
 import { db } from '@/lib/db'
-import { posts, morningState, users, wolfbotReviews } from '@/lib/db/schema'
+import { posts, morningState, users } from '@/lib/db/schema'
 import { and, desc, eq, inArray } from 'drizzle-orm'
 import AnimatedRoutineIcons from '@/components/AnimatedRoutineIcons'
+import { ROUTINE_ICON_MAP } from '@/components/RoutineIcons'
 import { deriveExcerpt } from '@/lib/posts'
 
 function formatDate(iso: string) {
@@ -50,24 +51,16 @@ function Avatar({ src, name, size = 40 }: { src: string | null; name: string; si
   )
 }
 
-// 1–8 → two-word band per scale type
-const SCALE_WORDS: Record<'happy' | 'body' | 'brain', string[]> = {
-  happy: ['Lost',    'Lost',    'Steady',  'Steady',  'Good',    'Good',    'Joyful',  'Joyful'],
-  body:  ['Drained', 'Drained', 'Moving',  'Moving',  'Charged', 'Charged', 'Buzzing', 'Buzzing'],
-  brain: ['Silent',  'Silent',  'Waking',  'Waking',  'Sharp',   'Sharp',   'Manic',   'Manic'],
+const SCALE_WORDS: Record<'happy' | 'body' | 'brain' | 'stress', string[]> = {
+  happy:  ['Lost',    'Lost',    'Steady',  'Steady',  'Good',    'Good',    'Joyful',  'Joyful'],
+  body:   ['Drained', 'Drained', 'Moving',  'Moving',  'Charged', 'Charged', 'Buzzing', 'Buzzing'],
+  brain:  ['Silent',  'Silent',  'Waking',  'Waking',  'Sharp',   'Sharp',   'Manic',   'Manic'],
+  stress: ['Crushed', 'Crushed', 'Tense',   'Tense',   'Alert',   'Alert',   'Hunting', 'Hunting'],
 }
 
 function scaleWord(val: number | null, type: keyof typeof SCALE_WORDS): string | null {
   if (!val || val < 1 || val > 8) return null
   return SCALE_WORDS[type][val - 1]
-}
-
-function scaleColour(val: number | null): string {
-  if (!val) return '#909090'
-  if (val <= 2) return '#909090'
-  if (val <= 4) return '#4A7FA5'
-  if (val <= 6) return '#A0622A'
-  return '#3AB87A'
 }
 
 type FeedPost = {
@@ -78,7 +71,6 @@ type FeedPost = {
   excerpt: string | null
   image: string | null
   wordCountTotal: number | null
-  wolfbotReviewed: boolean
   status: string
   authorId: string | null
   authorUsername: string | null
@@ -90,6 +82,8 @@ type FeedPost = {
   happyScale: number | null
   bodyScale: number | null
   brainScale: number | null
+  stressScale: number | null
+  topRitual: string | null
 }
 
 function FeedCard({ post, showAuthor }: { post: FeedPost; showAuthor: boolean }) {
@@ -99,20 +93,23 @@ function FeedCard({ post, showAuthor }: { post: FeedPost; showAuthor: boolean })
   const isDraft = post.status === 'draft'
   const cardUrl = isDraft ? `/edit/${post.id}` : url
 
-  const moodWord  = scaleWord(post.happyScale, 'happy')
-  const bodyWord  = scaleWord(post.bodyScale,  'body')
-  const brainWord = scaleWord(post.brainScale, 'brain')
-  const hasScales = !!(moodWord || bodyWord || brainWord)
+  const moodWord   = scaleWord(post.happyScale,  'happy')
+  const bodyWord   = scaleWord(post.bodyScale,   'body')
+  const brainWord  = scaleWord(post.brainScale,  'brain')
+  const stressWord = scaleWord(post.stressScale, 'stress')
+  const hasScales  = !!(moodWord || bodyWord || brainWord || stressWord)
 
   const completedRituals = post.checklist
     ? Object.values(post.checklist).filter(Boolean).length
     : 0
   const hasRituals = !!post.checklist && completedRituals > 0
 
+  const topRitualMeta = post.topRitual ? ROUTINE_ICON_MAP[post.topRitual] : null
+
   return (
     <article className="feed-card">
 
-      {/* ── Header: avatar + name + date ── */}
+      {/* Row 1: Profile */}
       {showAuthor && post.authorUsername ? (
         <Link href={`/${post.authorUsername}`} className="feed-card-author-link">
           <Avatar src={avatarSrc} name={authorName} size={40} />
@@ -131,36 +128,70 @@ function FeedCard({ post, showAuthor }: { post: FeedPost; showAuthor: boolean })
         </div>
       )}
 
-      {/* ── Title ── */}
+      {/* Row 2: Title */}
       <Link href={cardUrl} className="feed-card-title-link">
         <p className="feed-card-title">{post.title || 'Untitled'}</p>
       </Link>
 
-      {/* ── Scales strip ── */}
-      {hasScales && (
-        <div className="feed-card-scales">
-          {moodWord && (
-            <div className="feed-card-scale-pill">
-              <span className="feed-card-scale-label">MOOD</span>
-              <span className="feed-card-scale-word" style={{ color: scaleColour(post.happyScale) }}>{moodWord}</span>
+      {/* Row 3+4: Word count (L) + Rituals / top ritual (R) */}
+      {(post.wordCountTotal || hasRituals) && (
+        <div className="feed-card-stats-row">
+          {post.wordCountTotal ? (
+            <div className="feed-card-wordcount">
+              <span className="feed-card-wordcount-number">{post.wordCountTotal}</span>
+              <span className="feed-card-wordcount-label">words</span>
             </div>
-          )}
-          {bodyWord && (
-            <div className="feed-card-scale-pill">
-              <span className="feed-card-scale-label">BODY</span>
-              <span className="feed-card-scale-word" style={{ color: scaleColour(post.bodyScale) }}>{bodyWord}</span>
-            </div>
-          )}
-          {brainWord && (
-            <div className="feed-card-scale-pill">
-              <span className="feed-card-scale-label">BRAIN</span>
-              <span className="feed-card-scale-word" style={{ color: scaleColour(post.brainScale) }}>{brainWord}</span>
+          ) : <div />}
+
+          {hasRituals && (
+            <div className="feed-card-rituals-block">
+              <div className="feed-card-rituals-row">
+                <AnimatedRoutineIcons checklist={post.checklist!} size={18} />
+                <span className="feed-card-ritual-count">{completedRituals}</span>
+              </div>
+              {topRitualMeta && (
+                <div className="feed-card-top-ritual">
+                  <span className="feed-card-top-ritual-star">★</span>
+                  <topRitualMeta.Icon size={12} color={topRitualMeta.color} />
+                  <span className="feed-card-top-ritual-label">{topRitualMeta.label}</span>
+                </div>
+              )}
             </div>
           )}
         </div>
       )}
 
-      {/* ── Photo / fallback ── */}
+      {/* Row 5: How I Showed Up — 4 scales */}
+      {hasScales && (
+        <div className="feed-card-scales">
+          {moodWord && (
+            <div className="feed-card-scale-pill">
+              <span className="feed-card-scale-label">MOOD</span>
+              <span className="feed-card-scale-word">{moodWord}</span>
+            </div>
+          )}
+          {bodyWord && (
+            <div className="feed-card-scale-pill">
+              <span className="feed-card-scale-label">BODY</span>
+              <span className="feed-card-scale-word">{bodyWord}</span>
+            </div>
+          )}
+          {brainWord && (
+            <div className="feed-card-scale-pill">
+              <span className="feed-card-scale-label">BRAIN</span>
+              <span className="feed-card-scale-word">{brainWord}</span>
+            </div>
+          )}
+          {stressWord && (
+            <div className="feed-card-scale-pill">
+              <span className="feed-card-scale-label">STRESS</span>
+              <span className="feed-card-scale-word">{stressWord}</span>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Row 6: Photo / fallback — acts as visual separator between cards */}
       <Link href={cardUrl} className="feed-card-media-link">
         <div className="feed-card-media">
           {post.image
@@ -170,30 +201,35 @@ function FeedCard({ post, showAuthor }: { post: FeedPost; showAuthor: boolean })
         </div>
       </Link>
 
-      {/* ── Word count ── */}
-      {post.wordCountTotal ? (
-        <div className="feed-card-wordcount">
-          <span className="feed-card-wordcount-number">{post.wordCountTotal}</span>
-          <span className="feed-card-wordcount-label">words</span>
-        </div>
-      ) : null}
-
-      {/* ── Footer: rituals + WOLF|BOT badge ── */}
-      {(hasRituals || post.wolfbotReviewed) && (
-        <div className="feed-card-footer">
-          {hasRituals && (
-            <div className="feed-card-rituals">
-              <AnimatedRoutineIcons checklist={post.checklist!} size={14} />
-              <span className="feed-card-ritual-count">{completedRituals}/10</span>
-            </div>
-          )}
-          {post.wolfbotReviewed && (
-            <span className="feed-card-wolfbot-badge">WOLF|BOT ✓</span>
-          )}
-        </div>
-      )}
     </article>
   )
+}
+
+// ── Top ritual computation ─────────────────────────────────────────────────────
+// Returns the most-completed ritual key per authorId across the given posts + stateMap.
+function computeTopRituals(
+  rows: Array<{ id: string; authorId: string | null }>,
+  stateMap: Map<string, { routineChecklist: unknown }>
+): Record<string, string | null> {
+  const counts: Record<string, Record<string, number>> = {}
+  for (const row of rows) {
+    const aid = row.authorId
+    if (!aid) continue
+    const ms = stateMap.get(row.id)
+    if (!ms) continue
+    const cl = ms.routineChecklist as Record<string, boolean> | null
+    if (!cl) continue
+    if (!counts[aid]) counts[aid] = {}
+    for (const [key, done] of Object.entries(cl)) {
+      if (done) counts[aid][key] = (counts[aid][key] || 0) + 1
+    }
+  }
+  const result: Record<string, string | null> = {}
+  for (const [aid, ritualCounts] of Object.entries(counts)) {
+    const sorted = Object.entries(ritualCounts).sort((a, b) => b[1] - a[1])
+    result[aid] = sorted[0]?.[0] ?? null
+  }
+  return result
 }
 
 export default async function FeedPage({
@@ -234,24 +270,22 @@ export default async function FeedPage({
       .orderBy(desc(posts.date))
 
     const ids = rows.map(r => r.id)
-    const [states, reviews] = ids.length > 0
-      ? await Promise.all([
-          db.select().from(morningState).where(inArray(morningState.postId, ids)),
-          db.select({ postId: wolfbotReviews.postId }).from(wolfbotReviews).where(inArray(wolfbotReviews.postId, ids)),
-        ])
-      : [[], []]
+    const states = ids.length > 0
+      ? await db.select().from(morningState).where(inArray(morningState.postId, ids))
+      : []
 
-    const stateMap   = new Map(states.map(s => [s.postId, s]))
-    const reviewedIds = new Set(reviews.map(r => r.postId))
+    const stateMap = new Map(states.map(s => [s.postId, s]))
+    const topRitualByAuthor = computeTopRituals(rows, stateMap as Map<string, { routineChecklist: unknown }>)
 
     feedPosts = rows.map(({ content, ...r }) => ({
       ...r,
       excerpt: r.excerpt || deriveExcerpt(content) || null,
-      checklist: stateMap.get(r.id)?.routineChecklist as Record<string, boolean> | undefined,
-      happyScale: stateMap.get(r.id)?.happyScale ?? null,
-      bodyScale:  stateMap.get(r.id)?.bodyScale  ?? null,
-      brainScale: stateMap.get(r.id)?.brainScale ?? null,
-      wolfbotReviewed: reviewedIds.has(r.id),
+      checklist:   stateMap.get(r.id)?.routineChecklist as Record<string, boolean> | undefined,
+      happyScale:  stateMap.get(r.id)?.happyScale  ?? null,
+      bodyScale:   stateMap.get(r.id)?.bodyScale   ?? null,
+      brainScale:  stateMap.get(r.id)?.brainScale  ?? null,
+      stressScale: stateMap.get(r.id)?.stressScale ?? null,
+      topRitual:   r.authorId ? (topRitualByAuthor[r.authorId] ?? null) : null,
     }))
   } else {
     const rows = await db
@@ -282,24 +316,22 @@ export default async function FeedPage({
       .orderBy(desc(posts.date))
 
     const ids = rows.map(r => r.id)
-    const [states, reviews] = ids.length > 0
-      ? await Promise.all([
-          db.select().from(morningState).where(inArray(morningState.postId, ids)),
-          db.select({ postId: wolfbotReviews.postId }).from(wolfbotReviews).where(inArray(wolfbotReviews.postId, ids)),
-        ])
-      : [[], []]
+    const states = ids.length > 0
+      ? await db.select().from(morningState).where(inArray(morningState.postId, ids))
+      : []
 
-    const stateMap    = new Map(states.map(s => [s.postId, s]))
-    const reviewedIds = new Set(reviews.map(r => r.postId))
+    const stateMap = new Map(states.map(s => [s.postId, s]))
+    const topRitualByAuthor = computeTopRituals(rows, stateMap as Map<string, { routineChecklist: unknown }>)
 
     feedPosts = rows.map(({ content, ...r }) => ({
       ...r,
       excerpt: r.excerpt || deriveExcerpt(content) || null,
-      checklist: stateMap.get(r.id)?.routineChecklist as Record<string, boolean> | undefined,
-      happyScale: stateMap.get(r.id)?.happyScale ?? null,
-      bodyScale:  stateMap.get(r.id)?.bodyScale  ?? null,
-      brainScale: stateMap.get(r.id)?.brainScale ?? null,
-      wolfbotReviewed: reviewedIds.has(r.id),
+      checklist:   stateMap.get(r.id)?.routineChecklist as Record<string, boolean> | undefined,
+      happyScale:  stateMap.get(r.id)?.happyScale  ?? null,
+      bodyScale:   stateMap.get(r.id)?.bodyScale   ?? null,
+      brainScale:  stateMap.get(r.id)?.brainScale  ?? null,
+      stressScale: stateMap.get(r.id)?.stressScale ?? null,
+      topRitual:   r.authorId ? (topRitualByAuthor[r.authorId] ?? null) : null,
     }))
   }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -5596,7 +5596,7 @@ html[data-theme="light"] .pf-expand-btn:hover {
 }
 
 .feed-card {
-  padding: 1.4rem 0;
+  padding: 1.6rem 0;
   border-bottom: 1px solid rgba(74,127,165,0.1);
 }
 
@@ -5604,41 +5604,50 @@ html[data-theme="light"] .pf-expand-btn:hover {
   border-bottom: none;
 }
 
-.feed-card-author {
+/* ── Author header ── */
+.feed-card-author-link {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.65rem;
   text-decoration: none;
-  margin-bottom: 0.55rem;
+  margin-bottom: 0.8rem;
+}
+
+.feed-card-author-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
 }
 
 .feed-card-author-name {
   font-family: var(--font-inter), 'Helvetica Neue', Helvetica, Arial, sans-serif;
-  font-size: 0.78rem;
-  font-weight: 500;
+  font-size: 0.85rem;
+  font-weight: 600;
   color: var(--body-text, #4A4A4A);
-  opacity: 0.6;
-  transition: opacity 0.15s;
+  transition: color 0.15s;
 }
 
-.feed-card-author:hover .feed-card-author-name {
-  opacity: 1;
+.feed-card-author-link:hover .feed-card-author-name {
+  color: #4A7FA5;
 }
 
-.feed-card-link {
-  display: block;
-  text-decoration: none;
-  color: var(--body-text, #4A4A4A);
-}
-
-.feed-card-date {
+.feed-card-meta-date {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4rem;
+  font-family: var(--font-inter), 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 0.72rem;
+  color: #909090;
+}
+
+.feed-card-date-solo {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
   font-family: var(--font-inter), 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-size: 0.75rem;
   color: #909090;
-  margin-bottom: 0.3rem;
+  margin-bottom: 0.5rem;
 }
 
 .feed-card-draft-badge {
@@ -5652,18 +5661,144 @@ html[data-theme="light"] .pf-expand-btn:hover {
   border-radius: 3px;
 }
 
+/* ── Title ── */
+.feed-card-title-link {
+  display: block;
+  text-decoration: none;
+  color: var(--body-text, #4A4A4A);
+  margin-bottom: 0.9rem;
+}
+
 .feed-card-title {
-  font-size: clamp(1rem, 2.5vw, 1.15rem);
-  font-weight: 400;
-  margin: 0 0 0.3rem;
-  line-height: 1.4;
+  font-size: clamp(1.05rem, 3vw, 1.25rem);
+  font-weight: 600;
+  margin: 0;
+  line-height: 1.35;
   transition: color 0.15s ease;
 }
 
-.feed-card-link:hover .feed-card-title {
+.feed-card-title-link:hover .feed-card-title {
   color: #A0622A;
 }
 
+/* ── Scales strip ── */
+.feed-card-scales {
+  display: flex;
+  gap: 0;
+  margin-bottom: 0.9rem;
+}
+
+.feed-card-scale-pill {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  padding-right: 0.5rem;
+}
+
+.feed-card-scale-label {
+  font-family: var(--font-inter), 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  color: #909090;
+  text-transform: uppercase;
+}
+
+.feed-card-scale-word {
+  font-family: var(--font-inter), 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+/* ── Photo / fallback ── */
+.feed-card-media-link {
+  display: block;
+  text-decoration: none;
+  margin-bottom: 0.9rem;
+}
+
+.feed-card-media {
+  width: 100%;
+  height: 190px;
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.feed-card-photo {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.feed-card-photo-fallback {
+  width: 100%;
+  height: 100%;
+  background: rgba(74,127,165,0.07);
+}
+
+/* ── Word count ── */
+.feed-card-wordcount {
+  display: flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  margin-bottom: 0.75rem;
+}
+
+.feed-card-wordcount-number {
+  font-family: var(--font-inter), 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: #A0622A;
+  line-height: 1;
+}
+
+.feed-card-wordcount-label {
+  font-family: var(--font-inter), 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 0.72rem;
+  color: #909090;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+/* ── Footer: rituals + wolfbot ── */
+.feed-card-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.feed-card-rituals {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  opacity: 0.75;
+}
+
+.feed-card-ritual-count {
+  font-family: var(--font-inter), 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 0.72rem;
+  color: #909090;
+  white-space: nowrap;
+}
+
+.feed-card-wolfbot-badge {
+  font-family: var(--font-inter), 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: #A0622A;
+  background: rgba(160,98,42,0.1);
+  border: 1px solid rgba(160,98,42,0.2);
+  padding: 0.2rem 0.5rem;
+  border-radius: 3px;
+  white-space: nowrap;
+}
+
+/* legacy — kept for compat */
 .feed-card-excerpt {
   font-family: var(--font-inter), 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-size: 0.82rem;
@@ -5671,11 +5806,6 @@ html[data-theme="light"] .pf-expand-btn:hover {
   opacity: 0.55;
   margin: 0;
   line-height: 1.5;
-}
-
-.feed-card-rituals {
-  margin-top: 0.7rem;
-  opacity: 0.7;
 }
 
 .feed-empty {

--- a/app/globals.css
+++ b/app/globals.css
@@ -5596,11 +5596,7 @@ html[data-theme="light"] .pf-expand-btn:hover {
 }
 
 .feed-card {
-  padding: 1.6rem 0;
-  border-bottom: 1px solid rgba(74,127,165,0.1);
-}
-
-.feed-card:last-child {
+  padding: 1.6rem 0 0;
   border-bottom: none;
 }
 
@@ -5610,7 +5606,7 @@ html[data-theme="light"] .pf-expand-btn:hover {
   align-items: center;
   gap: 0.65rem;
   text-decoration: none;
-  margin-bottom: 0.8rem;
+  margin-bottom: 0.75rem;
 }
 
 .feed-card-author-info {
@@ -5666,14 +5662,14 @@ html[data-theme="light"] .pf-expand-btn:hover {
   display: block;
   text-decoration: none;
   color: var(--body-text, #4A4A4A);
-  margin-bottom: 0.9rem;
+  margin-bottom: 0.85rem;
 }
 
 .feed-card-title {
-  font-size: clamp(1.05rem, 3vw, 1.25rem);
-  font-weight: 600;
+  font-size: 1.6rem;
+  font-weight: 700;
   margin: 0;
-  line-height: 1.35;
+  line-height: 1.25;
   transition: color 0.15s ease;
 }
 
@@ -5681,62 +5677,13 @@ html[data-theme="light"] .pf-expand-btn:hover {
   color: #A0622A;
 }
 
-/* ── Scales strip ── */
-.feed-card-scales {
+/* ── Stats row: word count (L) + rituals block (R) ── */
+.feed-card-stats-row {
   display: flex;
-  gap: 0;
-  margin-bottom: 0.9rem;
-}
-
-.feed-card-scale-pill {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 0.2rem;
-  padding-right: 0.5rem;
-}
-
-.feed-card-scale-label {
-  font-family: var(--font-inter), 'Helvetica Neue', Helvetica, Arial, sans-serif;
-  font-size: 0.6rem;
-  font-weight: 700;
-  letter-spacing: 0.1em;
-  color: #909090;
-  text-transform: uppercase;
-}
-
-.feed-card-scale-word {
-  font-family: var(--font-inter), 'Helvetica Neue', Helvetica, Arial, sans-serif;
-  font-size: 1rem;
-  font-weight: 700;
-  line-height: 1;
-}
-
-/* ── Photo / fallback ── */
-.feed-card-media-link {
-  display: block;
-  text-decoration: none;
-  margin-bottom: 0.9rem;
-}
-
-.feed-card-media {
-  width: 100%;
-  height: 190px;
-  border-radius: 6px;
-  overflow: hidden;
-}
-
-.feed-card-photo {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  display: block;
-}
-
-.feed-card-photo-fallback {
-  width: 100%;
-  height: 100%;
-  background: rgba(74,127,165,0.07);
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.85rem;
 }
 
 /* ── Word count ── */
@@ -5744,7 +5691,6 @@ html[data-theme="light"] .pf-expand-btn:hover {
   display: flex;
   align-items: baseline;
   gap: 0.35rem;
-  margin-bottom: 0.75rem;
 }
 
 .feed-card-wordcount-number {
@@ -5763,39 +5709,104 @@ html[data-theme="light"] .pf-expand-btn:hover {
   letter-spacing: 0.08em;
 }
 
-/* ── Footer: rituals + wolfbot ── */
-.feed-card-footer {
+/* ── Rituals block (right side of stats row) ── */
+.feed-card-rituals-block {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.35rem;
 }
 
-.feed-card-rituals {
+.feed-card-rituals-row {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  opacity: 0.75;
+  gap: 0.45rem;
 }
 
 .feed-card-ritual-count {
   font-family: var(--font-inter), 'Helvetica Neue', Helvetica, Arial, sans-serif;
-  font-size: 0.72rem;
-  color: #909090;
-  white-space: nowrap;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--body-text, #4A4A4A);
+  opacity: 0.55;
 }
 
-.feed-card-wolfbot-badge {
-  font-family: var(--font-inter), 'Helvetica Neue', Helvetica, Arial, sans-serif;
+/* ── Top ritual highlight ── */
+.feed-card-top-ritual {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.feed-card-top-ritual-star {
   font-size: 0.62rem;
-  font-weight: 700;
-  letter-spacing: 0.06em;
   color: #A0622A;
-  background: rgba(160,98,42,0.1);
-  border: 1px solid rgba(160,98,42,0.2);
-  padding: 0.2rem 0.5rem;
-  border-radius: 3px;
-  white-space: nowrap;
+  line-height: 1;
+}
+
+.feed-card-top-ritual-label {
+  font-family: var(--font-inter), 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 0.68rem;
+  color: #909090;
+}
+
+/* ── Scales strip — 4 columns ── */
+.feed-card-scales {
+  display: flex;
+  gap: 0;
+  margin-bottom: 0.85rem;
+}
+
+.feed-card-scale-pill {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  padding-right: 0.4rem;
+}
+
+.feed-card-scale-label {
+  font-family: var(--font-inter), 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 0.55rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  color: #909090;
+  text-transform: uppercase;
+}
+
+.feed-card-scale-word {
+  font-family: var(--font-inter), 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 0.92rem;
+  font-weight: 700;
+  color: #A0622A;
+  line-height: 1;
+}
+
+/* ── Photo — acts as visual separator ── */
+.feed-card-media-link {
+  display: block;
+  text-decoration: none;
+}
+
+.feed-card-media {
+  width: 100%;
+  height: 190px;
+  overflow: hidden;
+  border-bottom: 1px solid rgba(0,0,0,0.07);
+  margin-bottom: 0;
+}
+
+.feed-card-photo {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.feed-card-photo-fallback {
+  width: 100%;
+  height: 100%;
+  background: rgba(74,127,165,0.06);
 }
 
 /* legacy — kept for compat */

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wolfman-website",
   "version": "0.1.12",
-  "appVersion": "0.1.23.7",
+  "appVersion": "0.1.24.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wolfman-website",
   "version": "0.1.12",
-  "appVersion": "0.1.24.0",
+  "appVersion": "0.1.24.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
- Strava-style scales strip: MOOD / BODY / BRAIN shown as human words
  (Lost→Joyful, Drained→Buzzing, Silent→Manic) colour-coded by intensity
- Fixed-height 190px media block — journal photo or muted fallback colour
- Word count displayed prominently (copper number + grey label)
- Ritual icons + count footer (e.g. 6/10) + WOLF|BOT ✓ badge when reviewed
- Avatar bumped to 40px; author name + date stacked in header
- DB query extended: image, wordCountTotal, happyScale, bodyScale, brainScale,
  wolfbotReviewed (joined from wolfbot_reviews) — both community + mine queries

v0.1.24.0

https://claude.ai/code/session_013psCNQbAfUGa4bhMLZFYqu